### PR TITLE
Added tzxwav option to decode stereo tape only from a specified channel

### DIFF
--- a/docs/tzxwav.md
+++ b/docs/tzxwav.md
@@ -11,7 +11,7 @@ Reads ZX Spectum tapes from a WAV file and converts it to TZX.
 ```
 tzxwav [-h] [-o TARGET] [-p] [-v] [-t {low,med,high}]
        [-T {low,med,high}] [-l {none,short,normal,long}] [-c CLOCK]
-       [-s START] [-e END] [-D] file
+       [-s START] [-e END] [-S {left,mix,right}] [-D] file
 ```
 
 * `file`: WAV file to read from. Supported is mono and stereo, 8 and 16 bit per channel, any sampling rate. Other file formats are not supported.
@@ -24,6 +24,7 @@ tzxwav [-h] [-o TARGET] [-p] [-v] [-t {low,med,high}]
 * `-s`, `--start`: Set the first frame of the WAV file to be read. If not set, the start of file is used.
 * `-e`, `--end`: Set the last frame of the WAV file to be read. For technical reasons, this limit may be exceeded by a few frames. If not set, or if set out of range, the file will be read to the end.
 * `-c`, `--clock`: Change reference Z80 CPU clock speed, in Hz. Default is 3500000. It is also useful for correcting a wrong playback speed. For example, if your tape was played back 5% too fast, adjust the clock to 3500000 * 5% = 3675000 to improve the results.
+* `-S`, `--stereo`: Select channel of the stereo WAV file to be used. Default is `mix` of both channels.
 * `-D`, `--debug`: Show debugging output. Useful for finding out why `tzxwav` was unable to correctly read a file. Prints detected blocks and their position frame in the WAV file. If given two times, also prints detected bits and bytes. If given three times, prints detected pulse lengths (in T states) and their WAV file position. If give four times, also prints the reason why a sync or bit pulse was rejected. Attention, it will create a *lot* of useless output!
 * `-h`, `--help`: Show help message and exit.
 

--- a/tzxwav
+++ b/tzxwav
@@ -29,6 +29,7 @@ from tzxlib.loader import TapeLoader
 tresholds  = { 'low': 500, 'med': 2500, 'high':5000 }
 tolerances = { 'low': 1.1,  'med': 1.2,  'high': 1.4 }
 leaderMins = { 'none': 2, 'short': 10, 'normal': 40, 'long': 100 }
+leftChMix = { 'left': 1,  'mix': 0.5,  'right': 0 }
 
 lastPercent = None
 startTime = None
@@ -92,6 +93,11 @@ parser.add_argument('-e', '--end',
             dest='end',
             type=int,
             help='End at WAV frame number')
+parser.add_argument('-S', '--stereo',
+            choices=['left', 'mix', 'right'],
+            default='mix',
+            dest='leftChMix',
+            help='channel selection (works only for stereo WAV files)')
 parser.add_argument('-D', '--debug',
             dest='debug',
             action='count',
@@ -103,6 +109,7 @@ loader = TapeLoader(debug=args.debug,
         treshold=tresholds[args.treshold],
         tolerance=tolerances[args.tolerance],
         leaderMin=leaderMins[args.leader],
+        leftChMix=leftChMix[args.leftChMix],
         cpufreq=args.clock,
         progress=showProgress if args.progress else None,
         verbose=args.verbose)


### PR DESCRIPTION
I found it useful to be able to rip a using only a single channel o stereo WAV. It saved me some time and space and often produces better results.