### PR TITLE
Various small features added to tzxcleanup, tzxwav and tzxls

### DIFF
--- a/tzxlib/loader.py
+++ b/tzxlib/loader.py
@@ -298,7 +298,7 @@ class TapeLoader():
 
         while self.samples[count] > bias:
             count += 1
-            if count > countH or count >= self.samples.maxlen:       # Added or condition else somtimes fatal index error
+            if count > countH or count >= self.samples.maxlen:       # Added count >= self.samples.maxlen else sometimes fatal index error
                 if self.debug >= 4:
                     print(' ! {} no wave end in range, count={}, bias={}'.format(tag, count, bias), file=sys.stderr)
                 return None

--- a/tzxlib/loader.py
+++ b/tzxlib/loader.py
@@ -67,7 +67,7 @@ class TapeLoader():
                     (tzxData, startPos, endPos) = self._loadBlock()
                     tzxbd.setup(tzxData)
                     tzx.blocks.append(tzxbd)
-                    if self.verbose and len(tzxData.data) > 10:        # skip short data
+                    if self.verbose: 
                         print(('{} {:9d} - {:9d} : {}').format(
                              str(datetime.timedelta(seconds=self.samples.toSeconds(startPos))),      # show time
                              startPos,

--- a/tzxlib/tapfile.py
+++ b/tzxlib/tapfile.py
@@ -26,6 +26,7 @@ from tzxlib.convert import convertToDump
 
 
 class TapFile():
+    showHexSample = False
     def create(data):
         if (len(data) == 19 or len(data) == 20) and data[0] == 0x00:        # Headers also allowd 20 bytes long
             return TapHeader(data)
@@ -50,6 +51,7 @@ class TapFile():
     def writeFragment(self, tzx):
         tzx.write(pack('<H', len(self.data)))
         tzx.write(self.data)
+
 
 
 class TapHeader(TapFile):
@@ -92,8 +94,10 @@ class TapHeader(TapFile):
             result = '%s: %s (%s bytes)' % (self.type(), self.name(), self.length())
         if not self.valid():
             result += ', CRC ERROR!'
-            result += " " + hexdump.hexdump(bytes(self.data)[:16], result='return')             # show 16 byte hexdump
+        if TapFile.showHexSample:
+            result += " " * (32 - len(result)) + hexdump.hexdump(bytes(self.data)[:16], result='return')[10:]           # show 16 byte hexdump
         return result
+
 
 
 class TapData(TapFile):
@@ -112,9 +116,6 @@ class TapData(TapFile):
             result = '%d bytes of data' % (len(self.data) - 2)
         if not self.valid():
             result += ', CRC ERROR!'
-        # or use convertToDump?
-        #r = string()
-        #convertToDump(self.data, r)
-        #result += " " + r
-        result += " " + hexdump.hexdump(bytes(self.data)[:16], result='return')             # show 16 byte hexdump
+        if TapFile.showHexSample:
+            result += " " * (32 - len(result)) + hexdump.hexdump(bytes(self.data)[:16], result='return')[10:]             # show 16 byte hexdump
         return result

--- a/tzxlib/tapfile.py
+++ b/tzxlib/tapfile.py
@@ -18,13 +18,16 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+import hexdump
 from struct import pack, unpack
 
 from tzxlib.convert import convert
+from tzxlib.convert import convertToDump
+
 
 class TapFile():
     def create(data):
-        if len(data) == 19 and data[0] == 0x00:
+        if (len(data) == 19 or len(data) == 20) and data[0] == 0x00:        # Headers also allowd 20 bytes long
             return TapHeader(data)
         else:
             return TapData(data)
@@ -89,6 +92,7 @@ class TapHeader(TapFile):
             result = '%s: %s (%s bytes)' % (self.type(), self.name(), self.length())
         if not self.valid():
             result += ', CRC ERROR!'
+            result += " " + hexdump.hexdump(bytes(self.data)[:16], result='return')             # show 16 byte hexdump
         return result
 
 
@@ -108,4 +112,9 @@ class TapData(TapFile):
             result = '%d bytes of data' % (len(self.data) - 2)
         if not self.valid():
             result += ', CRC ERROR!'
+        # or use convertToDump?
+        #r = string()
+        #convertToDump(self.data, r)
+        #result += " " + r
+        result += " " + hexdump.hexdump(bytes(self.data)[:16], result='return')             # show 16 byte hexdump
         return result

--- a/tzxtools/tzxcleanup.py
+++ b/tzxtools/tzxcleanup.py
@@ -45,7 +45,7 @@ def main():
     parser.add_argument('-H', '--headermustmatch',
                 dest='headermustmatch',
                 action='store_true',
-                help='also remove blocks not proceded by matching header')
+                help='Remove blocks not proceeded by matching header (keep only matching header-block pairs)')
     args = parser.parse_args()
 
     if args.file is None:
@@ -66,30 +66,40 @@ def main():
         if b.id == 0x11:        # turbo data
             b = b.asData()
         
+        # when args.headermustmatch keep last header found
         if args.headermustmatch and b.id == 0x10 and b.valid() and isinstance(b.tap, TapHeader) :
+            if blocklengthfromheader != 0:
+                # header after header makes the first one a orphan header
+                print("Orphan header: {} ({})".format(lastheader.tap.name().strip(), blocklengthfromheader), file=sys.stderr);                
+                headerlessCnt = headerlessCnt + 1  
             lastheader = b
             blocklengthfromheader = lastheader.tap.length()
+            continue
             
 
         # Use all data blocks for the output
         if b.id in [0x10, 0x11, 0x14]:
             if not b.valid():
                 crcCnt += 1
-            if b.valid() or not args.stripcrc:           
-                if (blocklengthfromheader == len(b.tap.data) - 2 and not isinstance(b.tap, TapHeader)) or not args.headermustmatch:
-                    if args.headermustmatch:                # else witten as normal block
-                        fout.blocks.append(lastheader)   
+            if b.valid() or not args.stripcrc:       
+                if args.headermustmatch:
+                    if blocklengthfromheader == len(b.tap.data) - 2 and not isinstance(b.tap, TapHeader):
+                        # this is a datablock with matching header
+                        fout.blocks.append(lastheader)      # write header only now
+                        fout.blocks.append(b) 
+                        numbytes += len(b.tap.data)
+                        blocklengthfromheader = 0   
+                else:
+                    # as before.
                     fout.blocks.append(b)
                     numbytes += len(b.tap.data)
-                elif not isinstance(b.tap, TapHeader):
-                    headerlessCnt = headerlessCnt + 1
-                    
-                if not isinstance(b.tap, TapHeader):                    
-                    blocklengthfromheader = 0
+            if blocklengthfromheader != 0:
+                print("Orphan header: {} ({})".format(lastheader.tap.name().strip(), blocklengthfromheader), file=sys.stderr);                
+                headerlessCnt = headerlessCnt + 1  
+                blocklengthfromheader = 0   
             continue
 
-        blocklengthfromheader = 0                
-
+        blocklengthfromheader = 0   
 
         # Use all pause blocks if they mean "stop the tape"
         if b.id in [0x20, 0x2A]:
@@ -111,7 +121,7 @@ def main():
     print('Blocks found:              %3d' % (len(file.blocks)), file=sys.stderr)
     print('Noise blocks removed:      %3d' % (noiseCnt), file=sys.stderr)
     print('Blocks with CRC errors:    %3d' % (crcCnt), file=sys.stderr)
-#    if(args.headermustmatch)
-    print('Skipped headerless blocks: %3d' % (headerlessCnt), file=sys.stderr)
+    if args.headermustmatch:
+        print('Skipped headerless blocks: %3d' % (headerlessCnt), file=sys.stderr)
     print('Blocks written:            %3d' % (len(fout.blocks)), file=sys.stderr)
     print('Total bytes written:       %3d' % (numbytes), file=sys.stderr)        # DJS

--- a/tzxtools/tzxls.py
+++ b/tzxtools/tzxls.py
@@ -41,6 +41,10 @@ def main():
                 dest='verbose',
                 action='store_true',
                 help='show content of information blocks')
+    parser.add_argument('-w', '--wide',
+                dest='printwide',
+                action='store_true',
+                help='output horizontal, comma separated')
     args = parser.parse_args()
 
     files = list(args.file)
@@ -59,14 +63,17 @@ def main():
         tzx.read(f)
 
         cnt = 0
+        endm = "\n"
+        if args.printwide:
+            endm = ", "
         for b in tzx.blocks:
             if args.short:
                 if hasattr(b, 'tap') and isinstance(b.tap, TapHeader):
-                    print('%s: %s' % (b.tap.type(), b.tap.name()))
+                    print('%s: %s' % (b.tap.type(), b.tap.name().strip() ), end=endm)
             else:
-                print('%3d  %-27s %s' % (cnt, b.type, str(b)))
+                print('%3d  %-27s %s' % (cnt, b.type, str(b)), end=endm)
             if args.verbose:
                 info = b.info()
                 if info is not None:
-                    print(textwrap.indent(info.strip(), '\t'))
+                    print(textwrap.indent(info.strip(), '\t'), end=endm)
             cnt += 1

--- a/tzxtools/tzxls.py
+++ b/tzxtools/tzxls.py
@@ -68,17 +68,20 @@ def main():
         tzx.read(f)
 
         cnt = 0
-        endm = "\n"     # endmarker either \n or ,
-        if args.printwide:
-            endm = ", "
+        sep = ""     # endmarker either \n or ,
         for b in tzx.blocks:
             if args.short:
                 if hasattr(b, 'tap') and isinstance(b.tap, TapHeader):
-                    print('%s: %s (%s)' % (b.tap.type(), b.tap.name().strip(), b.tap.length() ), end=endm)
+                    print('%s%s: %s (%s)' % (sep, b.tap.type(), b.tap.name().strip(), b.tap.length() ), end="")
             else:
-                print('%3d  %-27s %s' % (cnt, b.type, str(b)), end=endm)
+                print('%s%3d  %-27s %s' % (sep, cnt, b.type, str(b)), end="")
             if args.verbose:
                 info = b.info()
                 if info is not None:
-                    print(textwrap.indent(info.strip(), '\t'), end=endm)
+                    print(textwrap.indent(info.strip(), '\t'), end="")
             cnt += 1
+            if args.printwide:
+                sep = ", "
+            else: 
+                sep = "\n"     # endmarker either \n or ,
+        print("")              # extra \n

--- a/tzxtools/tzxls.py
+++ b/tzxtools/tzxls.py
@@ -24,7 +24,7 @@ import io
 import sys
 import textwrap
 
-from tzxlib.tapfile import TapHeader
+from tzxlib.tapfile import TapHeader, TapFile
 from tzxlib.tzxfile import TzxFile
 
 def main():
@@ -45,7 +45,12 @@ def main():
                 dest='printwide',
                 action='store_true',
                 help='output horizontal, comma separated')
+    parser.add_argument('-X', '--hexdump',
+                dest='hexdump',
+                action='store_true',
+                help='Show 16 byte sample hexdump after block data')
     args = parser.parse_args()
+    TapFile.showHexSample = args.hexdump
 
     files = list(args.file)
     if not sys.stdin.isatty() and len(files) == 0:
@@ -63,13 +68,13 @@ def main():
         tzx.read(f)
 
         cnt = 0
-        endm = "\n"
+        endm = "\n"     # endmarker either \n or ,
         if args.printwide:
             endm = ", "
         for b in tzx.blocks:
             if args.short:
                 if hasattr(b, 'tap') and isinstance(b.tap, TapHeader):
-                    print('%s: %s' % (b.tap.type(), b.tap.name().strip() ), end=endm)
+                    print('%s: %s (%s)' % (b.tap.type(), b.tap.name().strip(), b.tap.length() ), end=endm)
             else:
                 print('%3d  %-27s %s' % (cnt, b.type, str(b)), end=endm)
             if args.verbose:

--- a/tzxtools/tzxwav.py
+++ b/tzxtools/tzxwav.py
@@ -108,8 +108,12 @@ def main():
                 dest='debug',
                 action='count',
                 help='enable debug output, give multiple times to increase verbosity')
-
+    parser.add_argument('-X', '--hexdump',
+                dest='hexdump',
+                action='store_true',
+                help='Show 16 byte sample hexdump after block data')                  
     args = parser.parse_args()
+    TapFile.showHexSample = args.hexdump
 
     if args.file is None:
         parser.print_help(sys.stderr)

--- a/tzxtools/tzxwav.py
+++ b/tzxtools/tzxwav.py
@@ -24,6 +24,7 @@ import io
 import sys
 from time import time
 import wave
+from tzxlib.tapfile import TapFile
 
 from tzxlib.loader import TapeLoader
 


### PR DESCRIPTION
With your great tools I was able to recover 90% of my spectrum tapes. While doing so I added some features to tzxtools.
I am both new to python and new to github, (I have a C++ background) so forgive me if something is not according to the best practices...

tzxwav now shows the time (hours:min:secs) (from wave/tape start) of each found frame (when verbose).
tzxwav skips showing really short blocks (<10 bytes) even when verbose, to avoid some output.

tzxcleanup shows total number of bytes written, this gives a good indication of the quality of the original tzx (as created by tzxwav)
tzxcleanup can now skip data blocks that have no matching (zx spectrum) header, so only matching header/data pairs remain
Activated with commandline argument -H --headermustmatch
tzxcleanup shows number of headerless blocks skipped due to the above.
tzxcleanup fixed a rarely seen crash (index out of range). Had this with a old tzx file (not created with tzxwav). If needed I can try to roll back and reproduce?

tzxls with shartup argument -w /--wide can now show output comma separated on one line.

tzxlib a zx spectrum header is now allowed to be 20 bytes long as well (so 19 or 20) Had lots of headers with this length, especially games, that do work on real zx spectrum, but were otherwise showed as 'bogus'. Probably by copy program I used in the 1980's.

tzxlib (tzxls/tzxwav) show a 16 byte hex dump for each block when using verbose. Sometimes gives some a clue what it is (especially when bogus header)
