### PR TITLE
playback gain option

### DIFF
--- a/tzxtools/tzxplay.py
+++ b/tzxtools/tzxplay.py
@@ -39,7 +39,7 @@ silence = bytes(2048)
 numpySilence = numpy.zeros(1024, dtype=numpy.float32)
 
 
-def wavelet(length, level, sine=False, npy=False, loudness=1.0):
+def wavelet(length, level, sine=False, npy=False, gain=1.0):
     type = (length, level)
     if type in wavelets:
         return wavelets[type]
@@ -47,7 +47,7 @@ def wavelet(length, level, sine=False, npy=False, loudness=1.0):
     sign = 1 if level else -1
 
     if npy:
-        amp = (sign * (min(32767 * (length + 10) / 25, 32767) if sine else 32000) / 32767) * loudness
+        amp = (sign * (min(32767 * (length + 10) / 25, 32767) if sine else 32000) / 32767) * gain
         wave = numpy.empty(length, dtype=numpy.float32)
         for pos in range(length):
             wave[pos] = amp * sin(pos * pi / length) if sine else amp
@@ -66,7 +66,7 @@ def wavelet(length, level, sine=False, npy=False, loudness=1.0):
 def streamAudio(tzx:TzxFile, rate=44100, stopAlways=False, stop48k=False, sine=False, cpufreq=3500000, verbose=False, npy=False, gaindB=0.0):
     saver = TapeSaver(cpufreq)
 
-    loudness = (gaindB / 1.414 if gaindB > 0 else 1.414 / gaindB) if gaindB != 0.0 else 1.0
+    gain = (gaindB / 1.414 if gaindB > 0 else 1.414 / gaindB) if gaindB != 0.0 else 1.0
 
     block = 0
     repeatBlock = None
@@ -124,7 +124,7 @@ def streamAudio(tzx:TzxFile, rate=44100, stopAlways=False, stop48k=False, sine=F
                 newSampleTime = ((realTimeNs * rate) + 500000000) // 1000000000
                 wavelen = newSampleTime - currentSampleTime
                 if currentLevel != lastLevel:
-                    yield wavelet(wavelen, currentLevel, sine, npy, loudness)
+                    yield wavelet(wavelen, currentLevel, sine, npy, gain)
                 else:
                     while wavelen > 0:
                         if wavelen >= len(silence)//2:

--- a/tzxtools/tzxplay.py
+++ b/tzxtools/tzxplay.py
@@ -39,7 +39,7 @@ silence = bytes(2048)
 numpySilence = numpy.zeros(1024, dtype=numpy.float32)
 
 
-def wavelet(length, level, sine=False, npy=False, loudness=0.0):
+def wavelet(length, level, sine=False, npy=False, loudness=1.0):
     type = (length, level)
     if type in wavelets:
         return wavelets[type]


### PR DESCRIPTION
I was trying to load TAP/TZX images from my MacBook to my Speccy, but the default volume tzxplay outputs at was not enough. Initially I used Audacity with WAV files and set the gain there, but thought it would be a good idea to have the option of setting gain in tzxplay and skipping the extra step of having to export TAP files into WAV. The use of dB for gain is coming from Audacity. Tapes load flawlessly now.

I wanted to thank you for this amazing tool first and foremost, and would like to submit this feature to you. Maybe it will be useful for others as well.